### PR TITLE
Fixed bug.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,182 @@
+#
+# The clang-format (Clang 11) style file used by deal.II.
+#
+
+AccessModifierOffset: -2
+
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: true
+
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+
+AlwaysBreakAfterReturnType: All
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+
+BinPackArguments: false
+BinPackParameters: false
+
+BraceWrapping:
+  AfterCaseLabel: true
+  AfterClass: true
+  AfterControlStatement: Always
+  AfterEnum: true
+  AfterExternBlock: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+  AfterUnion: true
+  BeforeCatch: true
+  BeforeElse: true
+  BeforeLambdaBody: false
+  BeforeWhile: true
+  IndentBraces: true
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializers: BeforeComma
+BreakStringLiterals: false
+
+ColumnLimit: 80
+
+CompactNamespaces: false
+
+ConstructorInitializerIndentWidth: 2
+
+ContinuationIndentWidth: 2
+
+Cpp11BracedListStyle: true
+
+DerivePointerAlignment: false
+
+FixNamespaceComments: true
+
+IncludeBlocks: Regroup
+IncludeCategories:
+# config.h must always be first:
+  - Regex:    "deal.II/base/config.h"
+    Priority: -1
+# deal.II folders in sorted order:
+  - Regex:    "deal.II/algorithms/.*\\.h"
+    Priority: 100
+  - Regex:    "deal.II/arborx/.*\\.h"
+    Priority: 110
+  - Regex:    "deal.II/base/.*\\.h"
+    Priority: 120
+  - Regex:    "deal.II/boost_adaptors/.*\\.h"
+    Priority: 125
+  - Regex:    "deal.II/differentiation/.*\\.h"
+    Priority: 130
+  - Regex:    "deal.II/distributed/.*\\.h"
+    Priority: 140
+  - Regex:    "deal.II/dofs/.*\\.h"
+    Priority: 150
+  - Regex:    "deal.II/fe/.*\\.h"
+    Priority: 160
+  - Regex:    "deal.II/gmsh/.*\\.h"
+    Priority: 170
+  - Regex:    "deal.II/grid/.*\\.h"
+    Priority: 180
+  - Regex:    "deal.II/hp/.*\\.h"
+    Priority: 190
+  - Regex:    "deal.II/integrators/.*\\.h"
+    Priority: 200
+  - Regex:    "deal.II/lac/.*\\.h"
+    Priority: 210
+  - Regex:    "deal.II/matrix_free/.*\\.h"
+    Priority: 220
+  - Regex:    "deal.II/meshworker/.*\\.h"
+    Priority: 230
+  - Regex:    "deal.II/multigrid/.*\\.h"
+    Priority: 240
+  - Regex:    "deal.II/non_matching/.*\\.h"
+    Priority: 250
+  - Regex:    "deal.II/numerics/.*\\.h"
+    Priority: 260
+  - Regex:    "deal.II/opencascade/.*\\.h"
+    Priority: 270
+  - Regex:    "deal.II/optimization/.*\\.h"
+    Priority: 280
+  - Regex:    "deal.II/particles/.*\\.h"
+    Priority: 290
+  - Regex:    "deal.II/physics/.*\\.h"
+    Priority: 300
+  - Regex:    "deal.II/simplex/.*\\.h"
+    Priority: 310
+  - Regex:    "deal.II/sundials/.*\\.h"
+    Priority: 320
+# put boost right after deal:
+  - Regex: "<boost.*>"
+    Priority: 500
+# try to group PETSc headers:
+  - Regex: "<petsc.*\\.h>"
+    Priority: 1000
+# try to catch all third party headers and put them after deal.II but before
+# standard headers:
+  - Regex: "<.*\\.(h|hpp|hxx)>"
+    Priority: 2000
+# match all standard headers. Things like '#include <armadillo>' should be
+# surrounded by #ifdef checks (which will not be merged by clang-format) so they
+# should not be caught here
+  - Regex: "<[a-z_]+>"
+    Priority: 100000
+# make sure that "../tests.h" appears before all other local include files
+# such that replacing Assert in tests also applies to the testing header files.
+  - Regex: "\\.\\./tests\\.h"
+    Priority: 200000
+
+IndentCaseLabels: true
+IndentPPDirectives: AfterHash
+IndentWidth: 2
+
+IndentWrappedFunctionNames: false
+
+KeepEmptyLinesAtTheStartOfBlocks: false
+
+Language: Cpp
+
+MaxEmptyLinesToKeep: 3
+
+NamespaceIndentation: All
+
+PenaltyBreakBeforeFirstCallParameter: 90
+
+PointerAlignment: Right
+
+ReflowComments: true
+CommentPragmas: '( \| |\*--|<li>|@ref | @p |@param |@name |@returns |@warning |@ingroup |@author |@date |@related |@relates |@relatesalso |@deprecated |@image |@return |@brief |@attention |@copydoc |@addtogroup |@todo |@tparam |@see |@note |@skip |@skipline |@until |@line |@dontinclude |@include)'
+
+SortIncludes: true
+SortUsingDeclarations: true
+
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+
+Standard: Cpp11
+
+TabWidth: 2
+
+UseTab: Never

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,3 +22,4 @@ INCLUDE_DIRECTORIES(
 
 ADD_EXECUTABLE(project source/main.cc)
 DEAL_II_SETUP_TARGET(project)
+add_custom_target(indent clang-format -i source/*cc include/*h WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/include/StokesFSI.h
+++ b/include/StokesFSI.h
@@ -1,21 +1,9 @@
-#include <deal.II/base/quadrature_lib.h>
-#include <deal.II/base/logstream.h>
-#include <deal.II/base/function.h>
-#include <deal.II/base/utilities.h>
 #include <deal.II/base/discrete_time.h>
+#include <deal.II/base/function.h>
+#include <deal.II/base/logstream.h>
 #include <deal.II/base/parameter_acceptor.h>
-
-#include <deal.II/lac/block_vector.h>
-#include <deal.II/lac/full_matrix.h>
-#include <deal.II/lac/block_sparse_matrix.h>
-#include <deal.II/lac/solver_cg.h>
-#include <deal.II/lac/precondition.h>
-#include <deal.II/lac/affine_constraints.h>
-
-#include <deal.II/grid/tria.h>
-#include <deal.II/grid/grid_generator.h>
-#include <deal.II/grid/grid_tools.h>
-#include <deal.II/grid/grid_refinement.h>
+#include <deal.II/base/quadrature_lib.h>
+#include <deal.II/base/utilities.h>
 
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_renumbering.h>
@@ -27,23 +15,31 @@
 #include <deal.II/fe/fe_values.h>
 #include <deal.II/fe/mapping_q_eulerian.h>
 
+#include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/grid_refinement.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/tria.h>
 
-#include <deal.II/numerics/vector_tools.h>
-#include <deal.II/numerics/matrix_tools.h>
-#include <deal.II/numerics/data_out.h>
-#include <deal.II/numerics/error_estimator.h>
-
+#include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/block_sparse_matrix.h>
+#include <deal.II/lac/block_vector.h>
+#include <deal.II/lac/full_matrix.h>
+#include <deal.II/lac/precondition.h>
+#include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/sparse_direct.h>
 #include <deal.II/lac/sparse_ilu.h>
-#include <deal.II/lac/solver_cg.h>
 
+#include <deal.II/numerics/data_out.h>
+#include <deal.II/numerics/error_estimator.h>
+#include <deal.II/numerics/matrix_tools.h>
+#include <deal.II/numerics/vector_tools.h>
 
-#include <iostream>
+#include <cmath>
 #include <fstream>
+#include <iostream>
 #include <memory>
 #include <string>
-#include <cmath>
 
 
 using namespace dealii;
@@ -56,13 +52,13 @@ struct InnerPreconditioner;
 template <>
 struct InnerPreconditioner<2>
 {
-    using type = SparseDirectUMFPACK;
+  using type = SparseDirectUMFPACK;
 };
 
 template <>
 struct InnerPreconditioner<3>
 {
-    using type = SparseILU<double>;
+  using type = SparseILU<double>;
 };
 
 /* ------------------------------- */
@@ -71,9 +67,10 @@ template <class MatrixType, class PreconditionerType>
 class InverseMatrix : public Subscriptor
 {
 public:
-  InverseMatrix(const MatrixType &        m,
-                const PreconditionerType &preconditioner);
-  void vmult(Vector<double> &dst, const Vector<double> &src) const;
+  InverseMatrix(const MatrixType &m, const PreconditionerType &preconditioner);
+  void
+  vmult(Vector<double> &dst, const Vector<double> &src) const;
+
 private:
   const SmartPointer<const MatrixType>         matrix;
   const SmartPointer<const PreconditionerType> preconditioner;
@@ -87,7 +84,8 @@ InverseMatrix<MatrixType, PreconditionerType>::InverseMatrix(
 {}
 
 template <class MatrixType, class PreconditionerType>
-void InverseMatrix<MatrixType, PreconditionerType>::vmult(
+void
+InverseMatrix<MatrixType, PreconditionerType>::vmult(
   Vector<double> &      dst,
   const Vector<double> &src) const
 {
@@ -103,21 +101,23 @@ template <class PreconditionerType>
 class SchurComplement : public Subscriptor
 {
 public:
-    
-    SchurComplement(const BlockSparseMatrix<double> &system_matrix,
-                  const InverseMatrix<SparseMatrix<double>, PreconditionerType> &A_inverse);
-    void vmult(Vector<double> &dst, const Vector<double> &src) const;
-    
+  SchurComplement(
+    const BlockSparseMatrix<double> &system_matrix,
+    const InverseMatrix<SparseMatrix<double>, PreconditionerType> &A_inverse);
+  void
+  vmult(Vector<double> &dst, const Vector<double> &src) const;
+
 private:
-    
-    const SmartPointer<const BlockSparseMatrix<double>> system_matrix;
-    const SmartPointer<const InverseMatrix<SparseMatrix<double>, PreconditionerType>> A_inverse;
-    mutable Vector<double> tmp1, tmp2;
+  const SmartPointer<const BlockSparseMatrix<double>> system_matrix;
+  const SmartPointer<
+    const InverseMatrix<SparseMatrix<double>, PreconditionerType>>
+                         A_inverse;
+  mutable Vector<double> tmp1, tmp2;
 };
 
 template <class PreconditionerType>
 SchurComplement<PreconditionerType>::SchurComplement(
-  const BlockSparseMatrix<double> &system_matrix,
+  const BlockSparseMatrix<double> &                              system_matrix,
   const InverseMatrix<SparseMatrix<double>, PreconditionerType> &A_inverse)
   : system_matrix(&system_matrix)
   , A_inverse(&A_inverse)
@@ -141,17 +141,17 @@ SchurComplement<PreconditionerType>::vmult(Vector<double> &      dst,
 
 
 // Size of the "pool"
-const double lenght = 10.;        // x
-const double width = 3.;          // y
-const double height = 5.;         // z
+const double lenght = 10.; // x
+const double width  = 3.;  // y
+const double height = 5.;  // z
 
-const double max_displacement = 2;
-const double solid_liquid_height_proportion = 1./5;
-const unsigned int refinements = 3;
+const double       max_displacement               = 2;
+const double       solid_liquid_height_proportion = 1. / 5;
+const unsigned int refinements                    = 3;
 
 const double time_step = .1;
-const double mu = 1.;
-const double eta = .5;
+const double mu        = 1.;
+const double eta       = .5;
 
 
 /* ------------------------------- */
@@ -160,35 +160,37 @@ template <int dim>
 class InitialValues : public Function<dim>
 {
 public:
-    InitialValues()
-    : Function<dim>(dim+1) {}
-    
-    virtual double value(const Point<dim> & p,
-                       const unsigned int component) const override
-    {
-        const double XI = height*solid_liquid_height_proportion;
-        
-        if (component==0)
-            return 0;
-        else if (dim==3 and component==1)
-            return 0;
-        else if (component==dim-1)
-        {
-            if (p[component]<XI)
-                return 0;
-            else
-                return (1. - (2.*p[0])/10.)*max_displacement*(p[dim-1]-XI)/(height-XI);
-        }
-        else if (component==dim)
-            return 0.;
-    }
-    
-    virtual void vector_value(const Point<dim> &p,
-                              Vector<double> &  values) const override
-    {
-        for (unsigned int c = 0; c < this->n_components; ++c)
-            values(c) = this->value(p, c);
-    }
+  InitialValues()
+    : Function<dim>(dim + 1)
+  {}
+
+  virtual double
+  value(const Point<dim> &p, const unsigned int component) const override
+  {
+    const double XI = height * solid_liquid_height_proportion;
+
+    if (component == 0)
+      return 0;
+    else if (dim == 3 and component == 1)
+      return 0;
+    else if (component == dim - 1)
+      {
+        if (p[component] < XI)
+          return 0;
+        else
+          return (1. - (2. * p[0]) / 10.) * max_displacement *
+                 (p[dim - 1] - XI) / (height - XI);
+      }
+    else if (component == dim)
+      return 0.;
+  }
+
+  virtual void
+  vector_value(const Point<dim> &p, Vector<double> &values) const override
+  {
+    for (unsigned int c = 0; c < this->n_components; ++c)
+      values(c) = this->value(p, c);
+  }
 };
 
 /* ------------------------------- */
@@ -196,15 +198,15 @@ public:
 template <int dim>
 class RightHandSide : public Function<dim>
 {
-    
 public:
   RightHandSide()
-    : Function<dim>(dim + 1) {}
-    
-  virtual double value(const Point<dim> & p,
-                       const unsigned int material) const override;
-  virtual void vector_value(const Point<dim> &p,
-                            Vector<double> &  value) const override;
+    : Function<dim>(dim + 1)
+  {}
+
+  virtual double
+  value(const Point<dim> &p, const unsigned int material) const override;
+  virtual void
+  vector_value(const Point<dim> &p, Vector<double> &value) const override;
 };
 
 
@@ -213,91 +215,77 @@ public:
 template <int dim>
 double
 RightHandSide<dim>::value(const Point<dim> & /*p*/,
-                                 const unsigned int component) const
+                          const unsigned int component) const
 {
-    Assert(component < this->n_components,
-           ExcIndexRange(component, 0, this->n_components));
-    if (component == 1)
-        return -1.;
-    return 0;
+  Assert(component < this->n_components,
+         ExcIndexRange(component, 0, this->n_components));
+  if (component == 1)
+    return -1.;
+  return 0;
 }
 
 template <int dim>
-void RightHandSide<dim>::vector_value(const Point<dim> &p,
-                                      Vector<double> &  values) const
+void
+RightHandSide<dim>::vector_value(const Point<dim> &p,
+                                 Vector<double> &  values) const
 {
-    for (unsigned int c = 0; c < this->n_components; ++c)
-        values(c) = RightHandSide<dim>::value(p, c);
+  for (unsigned int c = 0; c < this->n_components; ++c)
+    values(c) = RightHandSide<dim>::value(p, c);
 }
 
 /* ------------------------------- */
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 template <int dim>
 class StokesFSI
 {
-    
 public:
-    
-    StokesFSI(const unsigned int degree);
-    void run();
-    
-    
-private:
-    
-    
-    const unsigned int degree;
-    
-    void make_grid();
-    void setup_dofs();
-    void assemble_system();
-    void solve();
-    void update_displacement();
-    void output_results(const unsigned int refinement_cycle) const;
-    
-    
-    
-    Triangulation<dim> triangulation;
-    FESystem<dim>      fe;
-    
-    DoFHandler<dim>    dh;
-    
-    AffineConstraints<double> constraints;
-    
-    BlockSparsityPattern      sparsity_pattern;
-    BlockSparseMatrix<double> system_matrix;
-    BlockSparsityPattern      preconditioner_sparsity_pattern;
-    BlockSparseMatrix<double> preconditioner_matrix;
-    
-    BlockVector<double>       solution;
-    BlockVector<double>       system_rhs;
-    
-    
-    
-    Vector<double>      displacement;
-    
-    DiscreteTime time;
+  StokesFSI(const unsigned int degree);
+  void
+  run();
 
-    std::shared_ptr<typename InnerPreconditioner<dim>::type> A_preconditioner;
-    
-    friend class RightHandSide<dim>;
-    
+
+private:
+  const unsigned int degree;
+
+  void
+  make_grid();
+  void
+  setup_dofs();
+  void
+  assemble_system();
+  void
+  solve();
+  void
+  update_displacement();
+  void
+  output_results(const unsigned int refinement_cycle) const;
+
+
+
+  Triangulation<dim> triangulation;
+  FESystem<dim>      fe;
+
+  DoFHandler<dim> dh;
+
+  AffineConstraints<double> constraints;
+
+  BlockSparsityPattern      sparsity_pattern;
+  BlockSparseMatrix<double> system_matrix;
+  BlockSparsityPattern      preconditioner_sparsity_pattern;
+  BlockSparseMatrix<double> preconditioner_matrix;
+
+  BlockVector<double> solution;
+  BlockVector<double> system_rhs;
+
+
+
+  Vector<double> displacement;
+
+  DiscreteTime time;
+
+  std::shared_ptr<typename InnerPreconditioner<dim>::type> A_preconditioner;
+
+  friend class RightHandSide<dim>;
 };

--- a/include/StokesFSI.h
+++ b/include/StokesFSI.h
@@ -141,17 +141,17 @@ SchurComplement<PreconditionerType>::vmult(Vector<double> &      dst,
 
 
 // Size of the "pool"
-const double lenght = 10.; // x
+const double length = 10.; // x
 const double width  = 3.;  // y
 const double height = 5.;  // z
 
-const double       max_displacement               = 2;
-const double       solid_liquid_height_proportion = 1. / 5;
-const unsigned int refinements                    = 3;
+const double       max_displacement               = 1;
+const double       solid_liquid_height_proportion = 1. / 2.;
+const unsigned int refinements                    = 5;
 
 const double time_step = .1;
-const double mu        = 1.;
-const double eta       = .5;
+const double mu        = 1000.;
+const double eta       = 1.0;
 
 
 /* ------------------------------- */
@@ -183,6 +183,7 @@ public:
       }
     else if (component == dim)
       return 0.;
+    return 0;
   }
 
   virtual void
@@ -279,9 +280,11 @@ private:
   BlockVector<double> solution;
   BlockVector<double> system_rhs;
 
+  Vector<double> material_mask;
 
-
-  Vector<double> displacement;
+  BlockVector<double> displacement;
+  std::unique_ptr<MappingQEulerian<dim, BlockVector<double>>>
+    displacement_mapping;
 
   DiscreteTime time;
 

--- a/source/main.cc
+++ b/source/main.cc
@@ -4,337 +4,337 @@
 
 template <int dim>
 StokesFSI<dim>::StokesFSI(const unsigned int degree)
-    : degree(degree)
-    , triangulation(Triangulation<dim>::maximum_smoothing)
-    , fe(FE_Q<dim>(degree + 1), dim, FE_Q<dim>(degree), 1)
-    , dh(triangulation)
-    , time(0.,1.,time_step)
+  : degree(degree)
+  , triangulation(Triangulation<dim>::maximum_smoothing)
+  , fe(FE_Q<dim>(degree + 1), dim, FE_Q<dim>(degree), 1)
+  , dh(triangulation)
+  , time(0., 1., time_step)
 {}
 
 template <int dim>
-void StokesFSI<dim>::make_grid()
+void
+StokesFSI<dim>::make_grid()
 {
-    
-        
-    const Point<dim> top_right = (dim == 2 ?
-                                  Point<dim>(lenght, height) :           // 2d
-                                  Point<dim>(lenght, width, height));    // 3d
-        
-    GridGenerator::hyper_rectangle(triangulation,Point<dim>(),top_right);
-    triangulation.refine_global(refinements);
-        
-    double cells_per_side = pow(triangulation.n_active_cells(), 1./dim);
-        
-    for (const auto &cell : triangulation.active_cell_iterators())
+  const Point<dim> top_right = (dim == 2 ? Point<dim>(lenght, height) : // 2d
+                                  Point<dim>(lenght, width, height));   // 3d
+
+  GridGenerator::hyper_rectangle(triangulation, Point<dim>(), top_right);
+  triangulation.refine_global(refinements);
+
+  double cells_per_side = pow(triangulation.n_active_cells(), 1. / dim);
+
+  for (const auto &cell : triangulation.active_cell_iterators())
     {
-        Point<dim> cell_center = cell->center();
-        
-        if (abs(cell_center[0] - (top_right[0]/2)) < (top_right[0]/cells_per_side) and
-            cell_center[dim-1] < solid_liquid_height_proportion*top_right[dim-1])
+      Point<dim> cell_center = cell->center();
+
+      if (abs(cell_center[0] - (top_right[0] / 2)) <
+            (top_right[0] / cells_per_side) and
+          cell_center[dim - 1] <
+            solid_liquid_height_proportion * top_right[dim - 1])
         {
-            if (dim==2)
+          if (dim == 2)
+            cell->set_material_id(1);
+          else
+            {
+              if (abs(cell_center[1] - (top_right[1] / 2)) <
+                  (top_right[1] / cells_per_side))
                 cell->set_material_id(1);
-            else
-            {
-                if (abs(cell_center[1] - (top_right[1]/2)) < (top_right[1]/cells_per_side))
-                    cell->set_material_id(1);
-                else
-                    cell->set_material_id(0);
+              else
+                cell->set_material_id(0);
             }
         }
-        else
-            cell->set_material_id(0);
-        
-        
-        for (const auto &face : cell->face_iterators())
+      else
+        cell->set_material_id(0);
+
+
+      for (const auto &face : cell->face_iterators())
         {
-            Point<dim> face_center = face->center();
-            
-            if (face_center[dim - 1] == 0.)
-                face->set_all_boundary_ids(1);                              // bottom
-            
-            else
+          Point<dim> face_center = face->center();
+
+          if (face_center[dim - 1] == 0.)
+            face->set_all_boundary_ids(1); // bottom
+
+          else
             {
-                if ( (face_center[0] == 0. or face_center[0] == lenght) or
-                     (dim==3 and (face_center[1] == 0. or face_center[1] == width)) )
-                    face->set_all_boundary_ids(2);                          // side
+              if ((face_center[0] == 0. or face_center[0] == lenght) or
+                  (dim == 3 and
+                   (face_center[1] == 0. or face_center[1] == width)))
+                face->set_all_boundary_ids(2); // side
             }
         }
-            
     }
-    
-    std::ofstream out("reference_grid_"+Utilities::int_to_string(dim)+"D.vtk");
-    GridOut       grid_out;
-    grid_out.write_vtk(triangulation, out);
-    std::cout << "Grid saved." << std::endl;
+
+  std::ofstream out("reference_grid_" + Utilities::int_to_string(dim) +
+                    "D.vtk");
+  GridOut       grid_out;
+  grid_out.write_vtk(triangulation, out);
+  std::cout << "Grid saved." << std::endl;
 }
 
 
 
 template <int dim>
-void StokesFSI<dim>::setup_dofs()
+void
+StokesFSI<dim>::setup_dofs()
 {
-    dh.distribute_dofs(fe);
-    DoFRenumbering::Cuthill_McKee(dh);
-    
-    std::vector<unsigned int> block_component(dim + 1, 0);
-    block_component[dim] = 1;
-    DoFRenumbering::component_wise(dh, block_component);
-    dh.distribute_dofs(fe);
+  dh.distribute_dofs(fe);
+  DoFRenumbering::Cuthill_McKee(dh);
 
-    
-    {
-        constraints.clear();
-        FEValuesExtractors::Vector velocities(0);
-        DoFTools::make_hanging_node_constraints(dh, constraints);
-        
-        DoFTools::make_zero_boundary_constraints(dh,
-                                                 1,
-                                                 constraints,
-                                                 fe.component_mask(velocities));
-        
-        std::set<types::boundary_id> no_normal_flux_boundaries;
-        no_normal_flux_boundaries.insert(2);
-        VectorTools::compute_no_normal_flux_constraints(dh,
-                                                        0,
-                                                        no_normal_flux_boundaries,
-                                                        constraints);
-    }
-    constraints.close();
-    
-    const std::vector<types::global_dof_index> dofs_per_block =
-      DoFTools::count_dofs_per_fe_block(dh, block_component);
-    const unsigned int n_v = dofs_per_block[0];
-    const unsigned int n_p = dofs_per_block[1];
-    std::cout << "   Number of active cells: " << triangulation.n_active_cells()
-              << std::endl
-              << "   Number of degrees of freedom: " << dh.n_dofs()
-              << " (" << n_v << '+' << n_p << ')' << std::endl;
-    
-    {
-        BlockDynamicSparsityPattern dsp(2, 2);
-        dsp.block(0, 0).reinit(n_v, n_v);
-        dsp.block(1, 0).reinit(n_p, n_v);
-        dsp.block(0, 1).reinit(n_v, n_p);
-        dsp.block(1, 1).reinit(n_p, n_p);
-        
-        dsp.collect_sizes();
-        
-        Table<2, DoFTools::Coupling> coupling(dim + 1, dim + 1);
-        
-        for (unsigned int c = 0; c < dim + 1; ++c)
-            for (unsigned int d = 0; d < dim + 1; ++d)
-                if (!((c == dim) && (d == dim)))
-                    coupling[c][d] = DoFTools::always;
-                else
-                    coupling[c][d] = DoFTools::none;
-        
-        DoFTools::make_sparsity_pattern(dh, coupling, dsp, constraints, false);
-        sparsity_pattern.copy_from(dsp);
-    }
-    
-    {
-        BlockDynamicSparsityPattern preconditioner_dsp(2, 2);
-        preconditioner_dsp.block(0, 0).reinit(n_v, n_v);
-        preconditioner_dsp.block(1, 0).reinit(n_p, n_v);
-        preconditioner_dsp.block(0, 1).reinit(n_v, n_p);
-        preconditioner_dsp.block(1, 1).reinit(n_p, n_p);
-        
-        preconditioner_dsp.collect_sizes();
-        
-        Table<2, DoFTools::Coupling> preconditioner_coupling(dim + 1, dim + 1);
-        
-        for (unsigned int c = 0; c < dim + 1; ++c)
-            for (unsigned int d = 0; d < dim + 1; ++d)
-                if (((c == dim) && (d == dim)))
-                    preconditioner_coupling[c][d] = DoFTools::always;
-                else
-                    preconditioner_coupling[c][d] = DoFTools::none;
-        DoFTools::make_sparsity_pattern(dh,
-                                        preconditioner_coupling,
-                                        preconditioner_dsp,
-                                        constraints,
-                                        false);
-        preconditioner_sparsity_pattern.copy_from(preconditioner_dsp);
-    }
-    
-    system_matrix.reinit(sparsity_pattern);
-    preconditioner_matrix.reinit(preconditioner_sparsity_pattern);
-    
-    solution.reinit(2);
-    solution.block(0).reinit(n_v);
-    solution.block(1).reinit(n_p);
-    solution.collect_sizes();
-    
-    system_rhs.reinit(2);
-    system_rhs.block(0).reinit(n_v);
-    system_rhs.block(1).reinit(n_p);
-    system_rhs.collect_sizes();
-    
-    
-    displacement.reinit(n_v+n_p);
-    /*
-    displacement.reinit(2);
-    displacement.block(0).reinit(n_v);
-    displacement.block(1).reinit(n_p);
-    displacement.collect_sizes();
-    */
-}
+  std::vector<unsigned int> block_component(dim + 1, 0);
+  block_component[dim] = 1;
+  DoFRenumbering::component_wise(dh, block_component);
+  dh.distribute_dofs(fe);
 
 
+  {
+    constraints.clear();
+    FEValuesExtractors::Vector velocities(0);
+    DoFTools::make_hanging_node_constraints(dh, constraints);
 
-template <int dim>
-void StokesFSI<dim>::assemble_system()
-{
-    system_matrix         = 0;
-    system_rhs            = 0;
-    preconditioner_matrix = 0;
-    QGauss<dim> quadrature_formula(degree + 2);
-    
-    //MappingQEulerian<dim> q2_mapping(2, dh, displacement);
-    FEValues<dim> fe_values(/*q2_mapping,*/
-                            fe,
-                            quadrature_formula,
-                            update_values | update_quadrature_points |
-                            update_JxW_values | update_gradients);
-    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
-    const unsigned int n_q_points = quadrature_formula.size();
-    FullMatrix<double> local_matrix(dofs_per_cell, dofs_per_cell);
-    FullMatrix<double> local_preconditioner_matrix(dofs_per_cell,
-                                                   dofs_per_cell);
-    
-    Vector<double>     local_rhs(dofs_per_cell);
-    std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
-    const RightHandSide<dim>    right_hand_side;
-    std::vector<Vector<double>> rhs_values(n_q_points, Vector<double>(dim + 1));
-    
-    const FEValuesExtractors::Vector velocities(0);
-    const FEValuesExtractors::Scalar pressure(dim);
-    
-    std::vector<SymmetricTensor<2, dim>> symgrad_phi_u(dofs_per_cell);
-    std::vector<double>                  div_phi_u(dofs_per_cell);
-    std::vector<double>                  phi_p(dofs_per_cell);
-    
-    for (const auto &cell : dh.active_cell_iterators())
-    {
-        /*double lambda = (cell->material_id() == 1 ?
-                         time_step*mu :
-                         eta);
-        */
-        double lambda = 2.;
-        fe_values.reinit(cell);
-        local_matrix                = 0;
-        local_preconditioner_matrix = 0;
-        local_rhs                   = 0;
-        right_hand_side.vector_value_list(fe_values.get_quadrature_points(),
-                                          rhs_values);
-          
-        for (unsigned int q = 0; q < n_q_points; ++q)
-        {
-            for (unsigned int k = 0; k < dofs_per_cell; ++k)
-            {
-                symgrad_phi_u[k] = fe_values[velocities].symmetric_gradient(k, q);
-                div_phi_u[k] = fe_values[velocities].divergence(k, q);
-                phi_p[k]     = fe_values[pressure].value(k, q);
-            }
-  
-            for (unsigned int i = 0; i < dofs_per_cell; ++i)
-            {
-                for (unsigned int j = 0; j <= i; ++j)
-                {
-                    local_matrix(i, j) +=
-                            (lambda * (symgrad_phi_u[i] * symgrad_phi_u[j]) // (1)
-                             - div_phi_u[i] * phi_p[j]                      // (2)
-                             - phi_p[i] * div_phi_u[j])                     // (3)
-                            * fe_values.JxW(q);                             // * dx
-                    local_preconditioner_matrix(i, j) +=
-                            (phi_p[i] * phi_p[j])                           // (4)
-                            * fe_values.JxW(q);                             // * dx
-                }
-                
-                const unsigned int component_i = fe.system_to_component_index(i).first;
-                local_rhs(i) +=
-                        (fe_values.shape_value(i, q)                        // (phi_u_i(x_q)
-                         * rhs_values[q](component_i))                      // * f(x_q))
-                * fe_values.JxW(q);                                 // * dx
-            }
-        }
+    DoFTools::make_zero_boundary_constraints(dh,
+                                             1,
+                                             constraints,
+                                             fe.component_mask(velocities));
 
-        
-        for (unsigned int i = 0; i < dofs_per_cell; ++i)
-            for (unsigned int j = i + 1; j < dofs_per_cell; ++j)
-            {
-                local_matrix(i, j) = local_matrix(j, i);
-                local_preconditioner_matrix(i, j) = local_preconditioner_matrix(j, i);
-                
-            }
-        
-        cell->get_dof_indices(local_dof_indices);
-        constraints.distribute_local_to_global(local_matrix,
-                                               local_rhs,
-                                               local_dof_indices,
-                                               system_matrix,
-                                               system_rhs);
-        
-        constraints.distribute_local_to_global(local_preconditioner_matrix,
-                                               local_dof_indices,
-                                               preconditioner_matrix);
-    }
-    
-    std::cout << "   Computing preconditioner..." << std::endl << std::flush;
-    
-    A_preconditioner = std::make_shared<typename InnerPreconditioner<dim>::type>();
-    A_preconditioner->initialize(system_matrix.block(0, 0),
-                                 typename InnerPreconditioner<dim>::type::AdditionalData());
-
-}
-
-
-
-template <int dim>
-void StokesFSI<dim>::solve()
-{
-    const InverseMatrix<SparseMatrix<double>, typename InnerPreconditioner<dim>::type>
-    A_inverse(system_matrix.block(0, 0), *A_preconditioner);
-    
-    Vector<double> tmp(solution.block(0).size());
-    {
-        Vector<double> schur_rhs(solution.block(1).size());
-        A_inverse.vmult(tmp, system_rhs.block(0));
-        system_matrix.block(1, 0).vmult(schur_rhs, tmp);
-        schur_rhs -= system_rhs.block(1);
-        SchurComplement<typename InnerPreconditioner<dim>::type> schur_complement(system_matrix, A_inverse);
-        
-        SolverControl            solver_control(solution.block(1).size(),
-                                                1e-6 * schur_rhs.l2_norm());
-        SolverCG<Vector<double>> cg(solver_control);
-        SparseILU<double> preconditioner;
-        preconditioner.initialize(preconditioner_matrix.block(1, 1),
-                                  SparseILU<double>::AdditionalData());
-        InverseMatrix<SparseMatrix<double>, SparseILU<double>> m_inverse(preconditioner_matrix.block(1, 1), preconditioner);
-        cg.solve(schur_complement, solution.block(1), schur_rhs, m_inverse);
-        constraints.distribute(solution);
-        std::cout << "  " << solver_control.last_step()
-                << " outer CG Schur complement iterations for pressure"
-                << std::endl;
-    }
-    {
-      system_matrix.block(0, 1).vmult(tmp, solution.block(1));
-      tmp *= -1;
-      tmp += system_rhs.block(0);
-      A_inverse.vmult(solution.block(0), tmp);
-      constraints.distribute(solution);
-    }
+    std::set<types::boundary_id> no_normal_flux_boundaries;
+    no_normal_flux_boundaries.insert(2);
+    VectorTools::compute_no_normal_flux_constraints(dh,
+                                                    0,
+                                                    no_normal_flux_boundaries,
+                                                    constraints);
   }
+  constraints.close();
+
+  const std::vector<types::global_dof_index> dofs_per_block =
+    DoFTools::count_dofs_per_fe_block(dh, block_component);
+  const unsigned int n_v = dofs_per_block[0];
+  const unsigned int n_p = dofs_per_block[1];
+  std::cout << "   Number of active cells: " << triangulation.n_active_cells()
+            << std::endl
+            << "   Number of degrees of freedom: " << dh.n_dofs() << " (" << n_v
+            << '+' << n_p << ')' << std::endl;
+
+  {
+    BlockDynamicSparsityPattern dsp(2, 2);
+    dsp.block(0, 0).reinit(n_v, n_v);
+    dsp.block(1, 0).reinit(n_p, n_v);
+    dsp.block(0, 1).reinit(n_v, n_p);
+    dsp.block(1, 1).reinit(n_p, n_p);
+
+    dsp.collect_sizes();
+
+    Table<2, DoFTools::Coupling> coupling(dim + 1, dim + 1);
+
+    for (unsigned int c = 0; c < dim + 1; ++c)
+      for (unsigned int d = 0; d < dim + 1; ++d)
+        if (!((c == dim) && (d == dim)))
+          coupling[c][d] = DoFTools::always;
+        else
+          coupling[c][d] = DoFTools::none;
+
+    DoFTools::make_sparsity_pattern(dh, coupling, dsp, constraints, false);
+    sparsity_pattern.copy_from(dsp);
+  }
+
+  {
+    BlockDynamicSparsityPattern preconditioner_dsp(2, 2);
+    preconditioner_dsp.block(0, 0).reinit(n_v, n_v);
+    preconditioner_dsp.block(1, 0).reinit(n_p, n_v);
+    preconditioner_dsp.block(0, 1).reinit(n_v, n_p);
+    preconditioner_dsp.block(1, 1).reinit(n_p, n_p);
+
+    preconditioner_dsp.collect_sizes();
+
+    Table<2, DoFTools::Coupling> preconditioner_coupling(dim + 1, dim + 1);
+
+    for (unsigned int c = 0; c < dim + 1; ++c)
+      for (unsigned int d = 0; d < dim + 1; ++d)
+        if (((c == dim) && (d == dim)))
+          preconditioner_coupling[c][d] = DoFTools::always;
+        else
+          preconditioner_coupling[c][d] = DoFTools::none;
+    DoFTools::make_sparsity_pattern(
+      dh, preconditioner_coupling, preconditioner_dsp, constraints, false);
+    preconditioner_sparsity_pattern.copy_from(preconditioner_dsp);
+  }
+
+  system_matrix.reinit(sparsity_pattern);
+  preconditioner_matrix.reinit(preconditioner_sparsity_pattern);
+
+  solution.reinit(2);
+  solution.block(0).reinit(n_v);
+  solution.block(1).reinit(n_p);
+  solution.collect_sizes();
+
+  system_rhs.reinit(2);
+  system_rhs.block(0).reinit(n_v);
+  system_rhs.block(1).reinit(n_p);
+  system_rhs.collect_sizes();
+
+
+  displacement.reinit(n_v + n_p);
+  /*
+  displacement.reinit(2);
+  displacement.block(0).reinit(n_v);
+  displacement.block(1).reinit(n_p);
+  displacement.collect_sizes();
+  */
+}
+
+
+
+template <int dim>
+void
+StokesFSI<dim>::assemble_system()
+{
+  system_matrix         = 0;
+  system_rhs            = 0;
+  preconditioner_matrix = 0;
+  QGauss<dim> quadrature_formula(degree + 2);
+
+  // MappingQEulerian<dim> q2_mapping(2, dh, displacement);
+  FEValues<dim>      fe_values(/*q2_mapping,*/
+                          fe,
+                          quadrature_formula,
+                          update_values | update_quadrature_points |
+                            update_JxW_values | update_gradients);
+  const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
+  const unsigned int n_q_points    = quadrature_formula.size();
+  FullMatrix<double> local_matrix(dofs_per_cell, dofs_per_cell);
+  FullMatrix<double> local_preconditioner_matrix(dofs_per_cell, dofs_per_cell);
+
+  Vector<double>                       local_rhs(dofs_per_cell);
+  std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
+  const RightHandSide<dim>             right_hand_side;
+  std::vector<Vector<double>> rhs_values(n_q_points, Vector<double>(dim + 1));
+
+  const FEValuesExtractors::Vector velocities(0);
+  const FEValuesExtractors::Scalar pressure(dim);
+
+  std::vector<SymmetricTensor<2, dim>> symgrad_phi_u(dofs_per_cell);
+  std::vector<double>                  div_phi_u(dofs_per_cell);
+  std::vector<double>                  phi_p(dofs_per_cell);
+
+  for (const auto &cell : dh.active_cell_iterators())
+    {
+      /*double lambda = (cell->material_id() == 1 ?
+                       time_step*mu :
+                       eta);
+      */
+      double lambda = 2.;
+      fe_values.reinit(cell);
+      local_matrix                = 0;
+      local_preconditioner_matrix = 0;
+      local_rhs                   = 0;
+      right_hand_side.vector_value_list(fe_values.get_quadrature_points(),
+                                        rhs_values);
+
+      for (unsigned int q = 0; q < n_q_points; ++q)
+        {
+          for (unsigned int k = 0; k < dofs_per_cell; ++k)
+            {
+              symgrad_phi_u[k] = fe_values[velocities].symmetric_gradient(k, q);
+              div_phi_u[k]     = fe_values[velocities].divergence(k, q);
+              phi_p[k]         = fe_values[pressure].value(k, q);
+            }
+
+          for (unsigned int i = 0; i < dofs_per_cell; ++i)
+            {
+              for (unsigned int j = 0; j <= i; ++j)
+                {
+                  local_matrix(i, j) +=
+                    (lambda * (symgrad_phi_u[i] * symgrad_phi_u[j]) // (1)
+                     - div_phi_u[i] * phi_p[j]                      // (2)
+                     - phi_p[i] * div_phi_u[j])                     // (3)
+                    * fe_values.JxW(q);                             // * dx
+                  local_preconditioner_matrix(i, j) +=
+                    (phi_p[i] * phi_p[j]) // (4)
+                    * fe_values.JxW(q);   // * dx
+                }
+
+              const unsigned int component_i =
+                fe.system_to_component_index(i).first;
+              local_rhs(i) += (fe_values.shape_value(i, q)   // (phi_u_i(x_q)
+                               * rhs_values[q](component_i)) // * f(x_q))
+                              * fe_values.JxW(q);            // * dx
+            }
+        }
+
+
+      for (unsigned int i = 0; i < dofs_per_cell; ++i)
+        for (unsigned int j = i + 1; j < dofs_per_cell; ++j)
+          {
+            local_matrix(i, j) = local_matrix(j, i);
+            local_preconditioner_matrix(i, j) =
+              local_preconditioner_matrix(j, i);
+          }
+
+      cell->get_dof_indices(local_dof_indices);
+      constraints.distribute_local_to_global(
+        local_matrix, local_rhs, local_dof_indices, system_matrix, system_rhs);
+
+      constraints.distribute_local_to_global(local_preconditioner_matrix,
+                                             local_dof_indices,
+                                             preconditioner_matrix);
+    }
+
+  std::cout << "   Computing preconditioner..." << std::endl << std::flush;
+
+  A_preconditioner =
+    std::make_shared<typename InnerPreconditioner<dim>::type>();
+  A_preconditioner->initialize(
+    system_matrix.block(0, 0),
+    typename InnerPreconditioner<dim>::type::AdditionalData());
+}
+
+
+
+template <int dim>
+void
+StokesFSI<dim>::solve()
+{
+  const InverseMatrix<SparseMatrix<double>,
+                      typename InnerPreconditioner<dim>::type>
+    A_inverse(system_matrix.block(0, 0), *A_preconditioner);
+
+  Vector<double> tmp(solution.block(0).size());
+  {
+    Vector<double> schur_rhs(solution.block(1).size());
+    A_inverse.vmult(tmp, system_rhs.block(0));
+    system_matrix.block(1, 0).vmult(schur_rhs, tmp);
+    schur_rhs -= system_rhs.block(1);
+    SchurComplement<typename InnerPreconditioner<dim>::type> schur_complement(
+      system_matrix, A_inverse);
+
+    SolverControl            solver_control(solution.block(1).size(),
+                                 1e-6 * schur_rhs.l2_norm());
+    SolverCG<Vector<double>> cg(solver_control);
+    SparseILU<double>        preconditioner;
+    preconditioner.initialize(preconditioner_matrix.block(1, 1),
+                              SparseILU<double>::AdditionalData());
+    InverseMatrix<SparseMatrix<double>, SparseILU<double>> m_inverse(
+      preconditioner_matrix.block(1, 1), preconditioner);
+    cg.solve(schur_complement, solution.block(1), schur_rhs, m_inverse);
+    constraints.distribute(solution);
+    std::cout << "  " << solver_control.last_step()
+              << " outer CG Schur complement iterations for pressure"
+              << std::endl;
+  }
+  {
+    system_matrix.block(0, 1).vmult(tmp, solution.block(1));
+    tmp *= -1;
+    tmp += system_rhs.block(0);
+    A_inverse.vmult(solution.block(0), tmp);
+    constraints.distribute(solution);
+  }
+}
 
 
 
 template <int dim>
 void
 StokesFSI<dim>::update_displacement()
-{
-    
-}
+{}
 
 
 
@@ -342,93 +342,94 @@ template <int dim>
 void
 StokesFSI<dim>::output_results(const unsigned int step) const
 {
-    std::vector<std::string> solution_names(dim, "velocity");
-    solution_names.emplace_back("pressure");
-      
-    std::vector<DataComponentInterpretation::DataComponentInterpretation>
+  std::vector<std::string> solution_names(dim, "velocity");
+  solution_names.emplace_back("pressure");
+
+  std::vector<DataComponentInterpretation::DataComponentInterpretation>
     data_component_interpretation(
-                                  dim, DataComponentInterpretation::component_is_part_of_vector);
-    data_component_interpretation.push_back(
-                                            DataComponentInterpretation::component_is_scalar);
-      
-    MappingQEulerian<dim> q2_mapping(2, dh, displacement);
-    
-    DataOut<dim> data_out;
-    data_out.attach_dof_handler(dh);
-    data_out.add_data_vector(solution,
-                             solution_names,
-                             DataOut<dim>::type_dof_data,
-                             data_component_interpretation);
-    data_out.build_patches(q2_mapping);
-    std::ofstream output("solution" + Utilities::int_to_string(dim, 1) + "D--" + Utilities::int_to_string(step, 3) + ".vtk");
-    data_out.write_vtk(output);
-    
-    /*
-    MappingQEulerian<dim> q2_mapping(2, dh_u, old_displacement);
-    DataOut<dim> data_out;
-    data_out.attach_dof_handler(dh_u);
-    data_out.add_data_vector(old_displacement,
-                            "Soluzione");
-    data_out.build_patches(q2_mapping);
-    
-    std::ofstream output(dim == 2 ? "solution-2d.vtk" : "solution-3d.vtk");
-    data_out.write_vtk(output);
-        
-    std::string s = std::to_string(dim);
-    std::ofstream out("grid" + s + ".vtk");
-    GridOut       grid_out;
-    grid_out.write_vtk(triangulation, out);
-    std::cout << "Grid written" << std::endl;
-    */
+      dim, DataComponentInterpretation::component_is_part_of_vector);
+  data_component_interpretation.push_back(
+    DataComponentInterpretation::component_is_scalar);
+
+  MappingQEulerian<dim> q2_mapping(2, dh, displacement);
+
+  DataOut<dim> data_out;
+  data_out.attach_dof_handler(dh);
+  data_out.add_data_vector(solution,
+                           solution_names,
+                           DataOut<dim>::type_dof_data,
+                           data_component_interpretation);
+  data_out.build_patches(q2_mapping);
+  std::ofstream output("solution" + Utilities::int_to_string(dim, 1) + "D--" +
+                       Utilities::int_to_string(step, 3) + ".vtk");
+  data_out.write_vtk(output);
+
+  /*
+  MappingQEulerian<dim> q2_mapping(2, dh_u, old_displacement);
+  DataOut<dim> data_out;
+  data_out.attach_dof_handler(dh_u);
+  data_out.add_data_vector(old_displacement,
+                          "Soluzione");
+  data_out.build_patches(q2_mapping);
+
+  std::ofstream output(dim == 2 ? "solution-2d.vtk" : "solution-3d.vtk");
+  data_out.write_vtk(output);
+
+  std::string s = std::to_string(dim);
+  std::ofstream out("grid" + s + ".vtk");
+  GridOut       grid_out;
+  grid_out.write_vtk(triangulation, out);
+  std::cout << "Grid written" << std::endl;
+  */
 }
 
 template <int dim>
 void
 StokesFSI<dim>::run()
 {
-    make_grid();
-    setup_dofs();
-    
-    VectorTools::project(dh,
-                         constraints,
-                         QGauss<dim>(degree + 2),
-                         InitialValues<dim>(),
-                         displacement);
-    
-    output_results(0);
-    
-    do
+  make_grid();
+  setup_dofs();
+
+  VectorTools::project(dh,
+                       constraints,
+                       QGauss<dim>(degree + 2),
+                       InitialValues<dim>(),
+                       displacement);
+
+  output_results(0);
+
+  do
     {
-        unsigned int step = time.get_step_number() + 1;
-        std::cout << "Timestep " << step << std::endl;
-        assemble_system();
-        solve();
-        update_displacement();
-        output_results(step);
-        
-        time.advance_time();
-        std::cout << "   Now at t=" << time.get_current_time()
-                  << ", dt=" << time.get_previous_step_size() << '.'
-                  << std::endl << std::endl;
+      unsigned int step = time.get_step_number() + 1;
+      std::cout << "Timestep " << step << std::endl;
+      assemble_system();
+      solve();
+      update_displacement();
+      output_results(step);
+
+      time.advance_time();
+      std::cout << "   Now at t=" << time.get_current_time()
+                << ", dt=" << time.get_previous_step_size() << '.' << std::endl
+                << std::endl;
     }
-    while (time.is_at_end() == false);
-    
-    std::cout << Utilities::int_to_string(dim, 1) + "D run finished."
-              << std::endl
-              << std::endl
-              << std::endl;
+  while (time.is_at_end() == false);
+
+  std::cout << Utilities::int_to_string(dim, 1) + "D run finished." << std::endl
+            << std::endl
+            << std::endl;
 }
 
 
-    
-int main()
+
+int
+main()
 {
   try
     {
       StokesFSI<2> problem(1);
       problem.run();
-      //StokesFSI<3> problems(1);
-      //problems.run();
+      // StokesFSI<3> problems(1);
+      // problems.run();
     }
   catch (std::exception &exc)
     {

--- a/source/main.cc
+++ b/source/main.cc
@@ -8,27 +8,32 @@ StokesFSI<dim>::StokesFSI(const unsigned int degree)
   , triangulation(Triangulation<dim>::maximum_smoothing)
   , fe(FE_Q<dim>(degree + 1), dim, FE_Q<dim>(degree), 1)
   , dh(triangulation)
-  , time(0., 1., time_step)
+  , time(0., 10., time_step)
 {}
 
 template <int dim>
 void
 StokesFSI<dim>::make_grid()
 {
-  const Point<dim> top_right = (dim == 2 ? Point<dim>(lenght, height) : // 2d
-                                  Point<dim>(lenght, width, height));   // 3d
+  const Point<dim> top_right = (dim == 2 ? Point<dim>(length, height) : // 2d
+                                  Point<dim>(length, width, height));   // 3d
 
   GridGenerator::hyper_rectangle(triangulation, Point<dim>(), top_right);
   triangulation.refine_global(refinements);
 
+  auto near = [](const auto &a, const auto &b) {
+    return std::abs(a - b) < 1e-10;
+  };
+
   double cells_per_side = pow(triangulation.n_active_cells(), 1. / dim);
 
+  material_mask.reinit(triangulation.n_active_cells());
   for (const auto &cell : triangulation.active_cell_iterators())
     {
       Point<dim> cell_center = cell->center();
 
       if (abs(cell_center[0] - (top_right[0] / 2)) <
-            (top_right[0] / cells_per_side) and
+            (top_right[0] / cells_per_side) &&
           cell_center[dim - 1] <
             solid_liquid_height_proportion * top_right[dim - 1])
         {
@@ -46,22 +51,26 @@ StokesFSI<dim>::make_grid()
       else
         cell->set_material_id(0);
 
+      material_mask[cell->index()] = cell->material_id();
 
       for (const auto &face : cell->face_iterators())
-        {
-          Point<dim> face_center = face->center();
+        if (face->at_boundary())
+          {
+            Point<dim> face_center = face->center();
 
-          if (face_center[dim - 1] == 0.)
-            face->set_all_boundary_ids(1); // bottom
+            if (near(face_center[dim - 1], 0))
+              face->set_all_boundary_ids(1); // bottom
 
-          else
-            {
-              if ((face_center[0] == 0. or face_center[0] == lenght) or
-                  (dim == 3 and
-                   (face_center[1] == 0. or face_center[1] == width)))
-                face->set_all_boundary_ids(2); // side
-            }
-        }
+            else if (near(face_center[0], 0.) || near(face_center[0], length) ||
+                     (dim == 3 && (near(face_center[1], 0.) ||
+                                   near(face_center[1], width))))
+              face->set_all_boundary_ids(2); // side
+
+            else
+              {
+                face->set_all_boundary_ids(0); // top}
+              }
+          }
     }
 
   std::ofstream out("reference_grid_" + Utilities::int_to_string(dim) +
@@ -83,8 +92,6 @@ StokesFSI<dim>::setup_dofs()
   std::vector<unsigned int> block_component(dim + 1, 0);
   block_component[dim] = 1;
   DoFRenumbering::component_wise(dh, block_component);
-  dh.distribute_dofs(fe);
-
 
   {
     constraints.clear();
@@ -96,12 +103,7 @@ StokesFSI<dim>::setup_dofs()
                                              constraints,
                                              fe.component_mask(velocities));
 
-    std::set<types::boundary_id> no_normal_flux_boundaries;
-    no_normal_flux_boundaries.insert(2);
-    VectorTools::compute_no_normal_flux_constraints(dh,
-                                                    0,
-                                                    no_normal_flux_boundaries,
-                                                    constraints);
+    VectorTools::compute_no_normal_flux_constraints(dh, 0, {2}, constraints);
   }
   constraints.close();
 
@@ -115,13 +117,7 @@ StokesFSI<dim>::setup_dofs()
             << '+' << n_p << ')' << std::endl;
 
   {
-    BlockDynamicSparsityPattern dsp(2, 2);
-    dsp.block(0, 0).reinit(n_v, n_v);
-    dsp.block(1, 0).reinit(n_p, n_v);
-    dsp.block(0, 1).reinit(n_v, n_p);
-    dsp.block(1, 1).reinit(n_p, n_p);
-
-    dsp.collect_sizes();
+    BlockDynamicSparsityPattern dsp(dofs_per_block, dofs_per_block);
 
     Table<2, DoFTools::Coupling> coupling(dim + 1, dim + 1);
 
@@ -137,13 +133,8 @@ StokesFSI<dim>::setup_dofs()
   }
 
   {
-    BlockDynamicSparsityPattern preconditioner_dsp(2, 2);
-    preconditioner_dsp.block(0, 0).reinit(n_v, n_v);
-    preconditioner_dsp.block(1, 0).reinit(n_p, n_v);
-    preconditioner_dsp.block(0, 1).reinit(n_v, n_p);
-    preconditioner_dsp.block(1, 1).reinit(n_p, n_p);
-
-    preconditioner_dsp.collect_sizes();
+    BlockDynamicSparsityPattern preconditioner_dsp(dofs_per_block,
+                                                   dofs_per_block);
 
     Table<2, DoFTools::Coupling> preconditioner_coupling(dim + 1, dim + 1);
 
@@ -161,24 +152,14 @@ StokesFSI<dim>::setup_dofs()
   system_matrix.reinit(sparsity_pattern);
   preconditioner_matrix.reinit(preconditioner_sparsity_pattern);
 
-  solution.reinit(2);
-  solution.block(0).reinit(n_v);
-  solution.block(1).reinit(n_p);
-  solution.collect_sizes();
+  solution.reinit(dofs_per_block);
+  system_rhs.reinit(dofs_per_block);
+  displacement.reinit(dofs_per_block);
 
-  system_rhs.reinit(2);
-  system_rhs.block(0).reinit(n_v);
-  system_rhs.block(1).reinit(n_p);
-  system_rhs.collect_sizes();
-
-
-  displacement.reinit(n_v + n_p);
-  /*
-  displacement.reinit(2);
-  displacement.block(0).reinit(n_v);
-  displacement.block(1).reinit(n_p);
-  displacement.collect_sizes();
-  */
+  displacement_mapping =
+    std::make_unique<MappingQEulerian<dim, BlockVector<double>>>(degree + 1,
+                                                                 dh,
+                                                                 displacement);
 }
 
 
@@ -192,8 +173,7 @@ StokesFSI<dim>::assemble_system()
   preconditioner_matrix = 0;
   QGauss<dim> quadrature_formula(degree + 2);
 
-  // MappingQEulerian<dim> q2_mapping(2, dh, displacement);
-  FEValues<dim>      fe_values(/*q2_mapping,*/
+  FEValues<dim>      fe_values(*displacement_mapping,
                           fe,
                           quadrature_formula,
                           update_values | update_quadrature_points |
@@ -217,11 +197,8 @@ StokesFSI<dim>::assemble_system()
 
   for (const auto &cell : dh.active_cell_iterators())
     {
-      /*double lambda = (cell->material_id() == 1 ?
-                       time_step*mu :
-                       eta);
-      */
-      double lambda = 2.;
+      double lambda = (cell->material_id() == 1 ? time_step * mu : eta);
+
       fe_values.reinit(cell);
       local_matrix                = 0;
       local_preconditioner_matrix = 0;
@@ -240,7 +217,7 @@ StokesFSI<dim>::assemble_system()
 
           for (unsigned int i = 0; i < dofs_per_cell; ++i)
             {
-              for (unsigned int j = 0; j <= i; ++j)
+              for (unsigned int j = 0; j < dofs_per_cell; ++j)
                 {
                   local_matrix(i, j) +=
                     (lambda * (symgrad_phi_u[i] * symgrad_phi_u[j]) // (1)
@@ -293,6 +270,13 @@ template <int dim>
 void
 StokesFSI<dim>::solve()
 {
+  //   // Let's first try a simple direct solver.
+  //   // This worked. There were issues with the numbering.
+  //   SparseDirectUMFPACK A_direct;
+  //   A_direct.initialize(system_matrix);
+  //   A_direct.vmult(solution, system_rhs);
+  //   constraints.distribute(solution);
+
   const InverseMatrix<SparseMatrix<double>,
                       typename InnerPreconditioner<dim>::type>
     A_inverse(system_matrix.block(0, 0), *A_preconditioner);
@@ -334,7 +318,9 @@ StokesFSI<dim>::solve()
 template <int dim>
 void
 StokesFSI<dim>::update_displacement()
-{}
+{
+  displacement.block(0).sadd(1.0, time_step, solution.block(0));
+}
 
 
 
@@ -351,18 +337,32 @@ StokesFSI<dim>::output_results(const unsigned int step) const
   data_component_interpretation.push_back(
     DataComponentInterpretation::component_is_scalar);
 
-  MappingQEulerian<dim> q2_mapping(2, dh, displacement);
-
   DataOut<dim> data_out;
   data_out.attach_dof_handler(dh);
   data_out.add_data_vector(solution,
                            solution_names,
                            DataOut<dim>::type_dof_data,
                            data_component_interpretation);
-  data_out.build_patches(q2_mapping);
-  std::ofstream output("solution" + Utilities::int_to_string(dim, 1) + "D--" +
-                       Utilities::int_to_string(step, 3) + ".vtk");
-  data_out.write_vtk(output);
+
+  data_out.add_data_vector(material_mask,
+                           "material",
+                           DataOut<dim>::type_cell_data);
+
+  data_out.build_patches(*displacement_mapping);
+  auto name = "solution" + Utilities::int_to_string(dim, 1) + "D--" +
+              Utilities::int_to_string(step, 3) + ".vtu";
+  std::ofstream output(name);
+  data_out.write_vtu(output);
+
+
+  // Output pvd record.
+  static std::vector<std::pair<double, std::string>> times_and_names;
+  times_and_names.push_back(std::make_pair(step * time_step, name));
+
+  std::ofstream pvd_output("solution_" + Utilities::int_to_string(dim, 1) +
+                           "D.pvd");
+  DataOutBase::write_pvd_record(pvd_output, times_and_names);
+
 
   /*
   MappingQEulerian<dim> q2_mapping(2, dh_u, old_displacement);
@@ -404,8 +404,8 @@ StokesFSI<dim>::run()
       std::cout << "Timestep " << step << std::endl;
       assemble_system();
       solve();
-      update_displacement();
       output_results(step);
+      update_displacement();
 
       time.advance_time();
       std::cout << "   Now at t=" << time.get_current_time()


### PR DESCRIPTION
You should only look at  e4cc296. The other one is only a commit used to guarantee we indent everything correctly.

I use `clang-format`, with the `.clang-format` file from the deal.II repository. If you have the deal.II source repository you can download it using `./contrib/utilities/download_clang_format`, and copy it somewhere in your path. Before you do a commit, you should run `make indent` or `ninja indent`. This will call `clang-format -i source/*cc include/*h`.